### PR TITLE
Allow caller to pass in dataDir

### DIFF
--- a/lib/error.js
+++ b/lib/error.js
@@ -1,4 +1,5 @@
 var Errors = {
+    "ArgsRequired": "No args were supplied",
     "RoutesNotDefined": "Routes are not defined, I dont know what to mock or proxy to :(",
     "HostOrPortNotDefined": "Host or/and Port are not defined can't run the server.",
     "RoutesMustBeArray": "Routes must be an array, even if there's only one route",

--- a/lib/proxkey.js
+++ b/lib/proxkey.js
@@ -31,13 +31,22 @@ Proxkey.Global = { Response: false };
 */
 
 
-/*
-    Set Proxy Configuration
-*/
+/**
+ * @public
+ * Set Proxy Configuration
+ * @param {object} args
+ * @param {object} args.configuration
+ * @param {object} args.configuration.port
+ * @param {object} args.configuration.host
+ * @param {boolean} [args.configuration.log] - If true, logs various information to console.
+ * @param {object} [args.configuration.dataDir] - The base directory where
+ *                 data responses are located.  Defaults to `require.main.filename`;
+ */
 Proxkey.setConfiguration = function(args) {
     Proxkey.Config.PORT = args.port ? args.port : 9191;
     Proxkey.Config.HOST = args.host ? args.host : 'localhost';
     Proxkey.Config.LOG = args.log ? args.log : true;
+    Proxkey.Config.DATA_DIR = args.dataDir;
 };
 
 /*
@@ -77,9 +86,14 @@ function proxyRoute(args, cb) {
 }
 
 function checkIfFileExsist(args, cb) {
-    var appDir = Path.dirname(require.main.filename);
+    var dataDir;
+    if (Proxkey.Config.DATA_DIR) {
+        dataDir = Proxkey.Config.DATA_DIR;
+    } else {
+        dataDir = Path.dirname(require.main.filename);
+    }
 
-    var path = appDir + '/' + args.path;
+    var path = Path.join(dataDir, args.path);
     fs.exists(path, function(exists) {
         if (exists) {
             cb(null, path);
@@ -155,7 +169,6 @@ function setHandlerForRoute(args, cb) {
             if (replace_args.response) {
 
             }
-
         }
 
         Proxkey.Global.Response = false;
@@ -256,7 +269,7 @@ function startServer() {
     };
 
     //Start Server
-    var server = Hapi.createServer(Proxkey.Config.HOST, Proxkey.Config.PORT,options);
+    var server = Hapi.createServer(Proxkey.Config.HOST, Proxkey.Config.PORT, options);
     server.route(Proxkey.Routes);
     server.start();
     console.log('Proxkey is running on ' + 'http://' + Proxkey.Config.HOST + ':' + Proxkey.Config.PORT);
@@ -306,7 +319,6 @@ function checkIfParamInMode (args, request, cb) {
         args.mode.forEach(function(val){
             //Regular queries - REST API
             _.findKey(Proxkey.Responses[request.route.path].params[val], function(params) {
-
                 var tmp_params = {};
                 tmp_params[params.key] = params.value;
                 if (_.isEqual(args.query_params,tmp_params)) {
@@ -329,8 +341,23 @@ function checkIfParamInMode (args, request, cb) {
     }
 }
 
+/**
+ * Starts the service.
+ * @public
+ * @param {object} args
+ * @param {object} args.configuration
+ * @param {object} args.configuration.port
+ * @param {object} args.configuration.host
+ * @param {object} args.routes - The array of routes to set. @see #setRoutes
+ * @param {boolean} [args.configuration.log] - If true, logs various information to console.
+ * @param {object} [args.configuration.dataDir] - The base directory where
+ *                 data responses are located.  Defaults to `require.main.filename`;
+ */
 Proxkey.start = function(args) {
-    // if args.configuration is defined
+    if (!args) {
+        throw new Error(Errors.ArgsRequired);
+    }
+
     if (!args.configuration || !args.configuration.port || !args.configuration.host) {
         throw new Error(Errors.HostOrPortNotDefined);
     }
@@ -344,10 +371,11 @@ Proxkey.start = function(args) {
     Proxkey.setRoutes(args.routes);
 };
 
-/*
-    Set Routes
-    (array) args
-*/
+/**
+ * Set Routes
+ * @public
+ * @param {array} args
+ */
 Proxkey.setRoutes = function(args) {
     if (!_.isArray(args)) {
         throw new Error(Errors.RoutesMustBeArray);

--- a/lib/proxkey.js
+++ b/lib/proxkey.js
@@ -128,7 +128,7 @@ function setHandlerForRoute(args, cb) {
             if (replace_args && replace_args.key && replace_args.val) {
                 if (replace_args.response && !_.isEmpty(args.query_params)) { //use response
 
-                    //Check if XML 
+                    //Check if XML
                     if (args.xml.mode) {
                         var xml_map = replace_args.response.split('->');
                         var tmp_val = args.xml.result;
@@ -142,12 +142,12 @@ function setHandlerForRoute(args, cb) {
                     }else {
                         replace_args.val = args[replace_args.response];
                     }
-                } 
+                }
                 var re = new RegExp(replace_args.key,"gi");
                 var data = Proxkey.Responses[request.route.path].response.success.data;
                 Proxkey.Responses[request.route.path].response.success.data = data.replace(re, replace_args.val);
                 replace_args.key = replace_args.val;
-            } else { return; } 
+            } else { return; }
 
         };
 
@@ -155,7 +155,7 @@ function setHandlerForRoute(args, cb) {
             if (replace_args.response) {
 
             }
-            
+
         }
 
         Proxkey.Global.Response = false;
@@ -263,75 +263,73 @@ function startServer() {
 }
 
 function checkIfParamInMode (args, request, cb) {
-	
-		if (args && args.xml && args.xml.mode) {
-			if (Proxkey.Config.LOG) {
-				console.log('looking for value in xml');
-			}
-			//SOAP - API parsing xml
-			args.mode.forEach(function(val){
-				_.findKey(Proxkey.Responses[request.route.path].params[val], function(params) { 
-					var tmp_params = {};
-					tmp_params[params.key] = params.value;
-					var tmp_key = params.key.split('->');
-					var tmp_xml = args.xml.result;
-					tmp_key.forEach(function(xml_key){
-						if (tmp_xml[xml_key]){
-							tmp_xml = tmp_xml[xml_key];
-						}
-					});
+    if (args && args.xml && args.xml.mode) {
+        if (Proxkey.Config.LOG) {
+            console.log('looking for value in xml');
+        }
+        //SOAP - API parsing xml
+        args.mode.forEach(function(val){
+            _.findKey(Proxkey.Responses[request.route.path].params[val], function(params) {
+                var tmp_params = {};
+                tmp_params[params.key] = params.value;
+                var tmp_key = params.key.split('->');
+                var tmp_xml = args.xml.result;
+                tmp_key.forEach(function(xml_key){
+                    if (tmp_xml[xml_key]){
+                        tmp_xml = tmp_xml[xml_key];
+                    }
+                });
 
-					if (_.isArray(tmp_xml)){
-						if (tmp_xml[0] == params.value) {
-							if (Proxkey.Config.LOG) {
-								console.log('Requested Found: response.' + val);
-							}
-							Proxkey.Global.Response = true;
-				  			return cb(null, {code: 'OK', mode: val});
-						}
-					} else {
-						if (tmp_xml == params.value) {
-							if (Proxkey.Config.LOG) {
-								console.log('Requested Found: response.' + val);
-							}
-							Proxkey.Global.Response = true;
-				  			return cb(null, {code: 'OK', mode: val});
-						}
-					}
-				});
-			});
-		} else { 
-			if (Proxkey.Config.LOG) {
-				console.log('looking for value in params');
-			}
-			args.mode.forEach(function(val){
-				//Regular queries - REST API
-				_.findKey(Proxkey.Responses[request.route.path].params[val], function(params) {
+                if (_.isArray(tmp_xml)){
+                    if (tmp_xml[0] == params.value) {
+                        if (Proxkey.Config.LOG) {
+                            console.log('Requested Found: response.' + val);
+                        }
+                        Proxkey.Global.Response = true;
+                        return cb(null, {code: 'OK', mode: val});
+                    }
+                } else {
+                    if (tmp_xml == params.value) {
+                        if (Proxkey.Config.LOG) {
+                            console.log('Requested Found: response.' + val);
+                        }
+                        Proxkey.Global.Response = true;
+                        return cb(null, {code: 'OK', mode: val});
+                    }
+                }
+            });
+        });
+    } else {
+        if (Proxkey.Config.LOG) {
+            console.log('looking for value in params');
+        }
+        args.mode.forEach(function(val){
+            //Regular queries - REST API
+            _.findKey(Proxkey.Responses[request.route.path].params[val], function(params) {
 
-					var tmp_params = {};
-					tmp_params[params.key] = params.value;
-					if (_.isEqual(args.query_params,tmp_params)) {
-						if (Proxkey.Config.LOG) {
-							console.log('Requested Found: response.' + val);
-						}
-						Proxkey.Global.Response = true;
-				  		return cb(null, {code: 'OK', mode: val});
-				  	}
-				});
-			});
-		}
-		
-	if (!Proxkey.Global.Response) {
-		if (Proxkey.Config.LOG) {
-			console.log('Requested Not Found: return response.success');
-		}
+                var tmp_params = {};
+                tmp_params[params.key] = params.value;
+                if (_.isEqual(args.query_params,tmp_params)) {
+                    if (Proxkey.Config.LOG) {
+                        console.log('Requested Found: response.' + val);
+                    }
+                    Proxkey.Global.Response = true;
+                    return cb(null, {code: 'OK', mode: val});
+                }
+            });
+        });
+    }
 
-		return cb({Error: 'Coludnt find the params, return defualt'}, null);
-	}
-};
+    if (!Proxkey.Global.Response) {
+        if (Proxkey.Config.LOG) {
+            console.log('Requested Not Found: return response.success');
+        }
+
+        return cb({Error: 'Coludnt find the params, return defualt'}, null);
+    }
+}
 
 Proxkey.start = function(args) {
-
     // if args.configuration is defined
     if (!args.configuration || !args.configuration.port || !args.configuration.host) {
         throw new Error(Errors.HostOrPortNotDefined);


### PR DESCRIPTION
These changes Allow the caller to pass in dataDir to use as base dir for relative paths to data response definitions.

This allows the project to work with pm2, and any other process manager that doesn't know what your CWD is.